### PR TITLE
Redirect demo.innovation.gov to digital.gov

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.1
+   2.1.4

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,25 +6,12 @@
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta http-equiv="Refresh" content="0; url=http://www.digital.gov"/>
 
     <title>{% if page.title %}{{ page.title | escape }} | {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
 
-    <!-- Redirect =============== -->
-    <script type="text/javascript">
-      var g_url = 'https://innovation.gov/';
-      var current_url = window.location;
-      if ( current_url.href.indexOf(g_url) >= 0 ) {
-        var path = current_url.href.replace(g_url, "");
-        window.location.href = 'https://www.digital.gov/' + path + '?=i';
-      }
-    </script>
-
   </head>
 
-  <body>
-    <main id="main">
-      Innovation.gov has moved to <a href="https://digital.gov">https://digital.gov</a>
-    </main>
-  </body>
+	<body></body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,17 +1,11 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
-
   <head>
     <meta charset="utf-8">
-
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta http-equiv="Refresh" content="0; url=http://www.digital.gov"/>
-
+    <meta http-equiv="Refresh" content="0; url=http://www.digital.gov"/>
     <title>{% if page.title %}{{ page.title | escape }} | {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-
   </head>
-
-	<body></body>
-
+  <body></body>
 </html>


### PR DESCRIPTION
- Removed code and copy for redirect
- Added new tag for automatic redirect digital.gov
- Will be archived

**Before**
<img width="976" alt="Screen Shot 2022-07-20 at 3 16 00 PM" src="https://user-images.githubusercontent.com/104778659/180064582-ec13b303-6f18-45bf-86c9-9e74f27d315e.png">

**After**

Automatically redirects to digital.gov